### PR TITLE
Refactor DeleteMultipleAsync method to use ExecuteDeleteAsync and simplify code logic

### DIFF
--- a/src/Devantler.DataProduct/Features/DataStore/Repositories/SQLRepository.cs
+++ b/src/Devantler.DataProduct/Features/DataStore/Repositories/SQLRepository.cs
@@ -98,9 +98,5 @@ public abstract class SQLRepository<TKey, TEntity> : IRepository<TKey, TEntity>
 
     /// <inheritdoc />
     public async Task DeleteMultipleAsync(IEnumerable<TKey> ids, CancellationToken cancellationToken = default)
-    {
-        var entities = await _context.Set<TEntity>().Where(x => ids.Contains(x.Id)).ToListAsync(cancellationToken);
-        _context.Set<TEntity>().RemoveRange(entities);
-        _ = await _context.SaveChangesAsync(cancellationToken);
-    }
+        => await _context.Set<TEntity>().Where(x => ids.Contains(x.Id)).ExecuteDeleteAsync(cancellationToken: cancellationToken);
 }


### PR DESCRIPTION
This commit updates the DeleteMultipleAsync method in SQLRepository to use the ExecuteDeleteAsync method. This improved bulk performance a lot, but is only possible with the Delete endpoint because of restrictions in the API requiring mapping the objects properties to the sql query.