### PR TITLE
refactor: remove FluentAssertions from Devantler.DataProduct.Generator.Tests.Unit

### DIFF
--- a/tests/Devantler.DataProduct.Generator.Tests.Unit/BannedSymbols.txt
+++ b/tests/Devantler.DataProduct.Generator.Tests.Unit/BannedSymbols.txt
@@ -1,1 +1,0 @@
-T:Xunit.Assert;Use 'FluentAssertions' instead.

--- a/tests/Devantler.DataProduct.Generator.Tests.Unit/Devantler.DataProduct.Generator.Tests.Unit.csproj
+++ b/tests/Devantler.DataProduct.Generator.Tests.Unit/Devantler.DataProduct.Generator.Tests.Unit.csproj
@@ -14,7 +14,6 @@
         <Using Include="AutoFixture.AutoNSubstitute" />
         <Using Include="AutoFixture.Xunit2" />
         <Using Include="AutoFixture" />
-        <Using Include="FluentAssertions" />
         <Using Include="NSubstitute" />
         <Using Include="Xunit" />
     </ItemGroup>
@@ -24,8 +23,6 @@
         <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
         <PackageReference Include="AutoFixture" Version="4.18.0" />
         <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="all" />
-        <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2" />
-        <PackageReference Include="FluentAssertions" Version="6.11.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
@@ -33,7 +30,8 @@
         <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16" />
         <PackageReference Include="System.CodeDom" Version="7.0.0" />
         <PackageReference Include="Verify.SourceGenerators" Version="2.1.0" />
-        <PackageReference Include="Verify.XUnit" Version="19.12.3" />
+        <PackageReference Include="Verify.XUnit" Version="19.13.0" />
+        <PackageReference Include="xunit.analyzers" Version="1.1.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
         <PackageReference Include="xunit" Version="2.4.2" />
     </ItemGroup>
@@ -41,10 +39,6 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\Devantler.DataProduct.Generator\Devantler.DataProduct.Generator.csproj" />
         <ProjectReference Include="..\..\src\Devantler.DataProduct\Devantler.DataProduct.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <AdditionalFiles Include="BannedSymbols.txt" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Devantler.DataProduct.Generator.Tests.Unit/IncrementalGenerators/DbContextGeneratorTests/GenerateTests.cs
+++ b/tests/Devantler.DataProduct.Generator.Tests.Unit/IncrementalGenerators/DbContextGeneratorTests/GenerateTests.cs
@@ -61,10 +61,9 @@ public class GenerateTests : IncrementalGeneratorTestsBase<DbContextGenerator>
 
         //Act
         var driver = RunGenerator(additionalText);
-        Func<Task> act = () => Verify(driver);
+        Task act() => Verify(driver);
 
         //Assert
-        // Check that the task contains a NotSupported exception
-        _ = act.Should().ThrowAsync<NotSupportedException>();
+        _ = Assert.ThrowsAsync<NotSupportedException>(act);
     }
 }


### PR DESCRIPTION
- Removed FluentAssertions and FluentAssertions.Analyzers packages from Devantler.DataProduct.Generator.Tests.Unit since they were replaced by other packages.
- Updated Verify.XUnit to version 19.13.0 and added xunit.analyzers to Devantler.DataProduct.Generator.Tests.Unit.
- Updated GenerateTests.cs by replacing the use of Func<Task> with Task to verify that the task contains a NotSupported exception.