### PR TITLE
Update cancellationToken handling in async methods

### DIFF
--- a/src/Devantler.DataProduct/Features/DataCatalog/Services/DataHubDataCatalogService.cs
+++ b/src/Devantler.DataProduct/Features/DataCatalog/Services/DataHubDataCatalogService.cs
@@ -51,7 +51,7 @@ public class DataHubDataCatalogService : BackgroundService
   }
 
   /// <inheritdoc />
-  public override async Task StopAsync(CancellationToken cancellationToken)
+  public override async Task StopAsync(CancellationToken cancellationToken = default)
       => await base.StopAsync(cancellationToken);
 
   void AddLinks(string urn, Metadata metadata)

--- a/src/Devantler.DataProduct/Features/Inputs/Services/FileInputService.cs
+++ b/src/Devantler.DataProduct/Features/Inputs/Services/FileInputService.cs
@@ -81,6 +81,6 @@ public class FileInputService<TKey, TSchema> : BackgroundService
   }
 
   /// <inheritdoc />
-  public override async Task StopAsync(CancellationToken cancellationToken)
+  public override async Task StopAsync(CancellationToken cancellationToken = default)
       => await base.StopAsync(cancellationToken);
 }

--- a/src/Devantler.DataProduct/Features/Inputs/Services/KafkaInputService.cs
+++ b/src/Devantler.DataProduct/Features/Inputs/Services/KafkaInputService.cs
@@ -74,7 +74,7 @@ public class KafkaInputService<TKey, TSchema> : BackgroundService where TSchema 
   }
 
   /// <inheritdoc />
-  public override async Task StopAsync(CancellationToken cancellationToken)
+  public override async Task StopAsync(CancellationToken cancellationToken = default)
   {
     foreach (var consumer in _consumers)
     {

--- a/src/Devantler.SchemaRegistry.Client/LocalSchemaRegistryClient.cs
+++ b/src/Devantler.SchemaRegistry.Client/LocalSchemaRegistryClient.cs
@@ -72,7 +72,7 @@ public class LocalSchemaRegistryClient : ISchemaRegistryClient
   /// <param name="version"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  async Task<string> GetSchemaStringAsync(string subject, int version, CancellationToken cancellationToken)
+  async Task<string> GetSchemaStringAsync(string subject, int version, CancellationToken cancellationToken = default)
   {
     string schemaFileName = $"{subject}-v{version}.avsc";
 

--- a/tests/Devantler.DataProduct.Generator.Tests.Unit/IncrementalGenerators/GraphQlQueryGeneratorTests/GenerateTests.record-schema-primitive-types#Query.g.verified.cs
+++ b/tests/Devantler.DataProduct.Generator.Tests.Unit/IncrementalGenerators/GraphQlQueryGeneratorTests/GenerateTests.record-schema-primitive-types#Query.g.verified.cs
@@ -14,7 +14,7 @@ public partial class Query
     [UseProjection]
     [UseFiltering]
     [UseSorting]
-  public async Task<IEnumerable<RecordSchemaPrimitiveTypes>> GetRecordSchemaPrimitiveTypes([Service] IDataStoreService<Guid, RecordSchemaPrimitiveTypes> dataStoreService, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<RecordSchemaPrimitiveTypes>> GetRecordSchemaPrimitiveTypes([Service] IDataStoreService<Guid, RecordSchemaPrimitiveTypes> dataStoreService, CancellationToken cancellationToken)
         => await dataStoreService.ReadAllAsync(cancellationToken);
 
 }

--- a/tests/Devantler.DataProduct.Generator.Tests.Unit/IncrementalGenerators/GraphQlQueryGeneratorTests/GenerateTests.record-schema-primitive-types#Query.g.verified.cs
+++ b/tests/Devantler.DataProduct.Generator.Tests.Unit/IncrementalGenerators/GraphQlQueryGeneratorTests/GenerateTests.record-schema-primitive-types#Query.g.verified.cs
@@ -14,7 +14,7 @@ public partial class Query
     [UseProjection]
     [UseFiltering]
     [UseSorting]
-    public async Task<IEnumerable<RecordSchemaPrimitiveTypes>> GetRecordSchemaPrimitiveTypes([Service] IDataStoreService<Guid, RecordSchemaPrimitiveTypes> dataStoreService, CancellationToken cancellationToken)
+  public async Task<IEnumerable<RecordSchemaPrimitiveTypes>> GetRecordSchemaPrimitiveTypes([Service] IDataStoreService<Guid, RecordSchemaPrimitiveTypes> dataStoreService, CancellationToken cancellationToken = default)
         => await dataStoreService.ReadAllAsync(cancellationToken);
 
 }


### PR DESCRIPTION
Add default values for cancellationToken in StopAsync and GetSchemaStringAsync methods while removing the default value in GetRecordSchemaPrimitiveTypes method to ensure consistent behavior across the API.